### PR TITLE
#16761403 Users should be able to see filtered trips based on destination

### DIFF
--- a/UI/html/basedOnDestination.html
+++ b/UI/html/basedOnDestination.html
@@ -1,0 +1,113 @@
+<html><header>
+        <title>wayfare add trip</title>
+    <link href="../css/style.css" type="text/css" rel="stylesheet"></header>
+    <script src="../js/main.js"></script>
+    <body>
+        <div class="navbar">
+    <h3 class="text-primary"> Wayfarer Bus Transportation </h3>
+    </div>
+    <div class="menu">
+        <ul>
+            <li><a href="index.html">home</a></li>
+                
+                <li><a href="basedOnDestination.html">destination Trip filter</a></li>
+                <li><a href="basedOnOrigin.html">origin Trip filter</a></li>
+                
+                
+                
+
+        </ul>
+    </div>
+        
+        <div class="contents">
+         <h3 class="text-primary">These are trip filtered based on origin </h3> <hr>
+         <input placeholder="search based on origin"
+          id="keyword" type="text" onkeyup="filterDestination()">
+          <table id="destTable" class="table-stripped">
+              
+            <tr>
+                  <th>Trip id</th>
+                  
+                  <th>Trip date</th>
+                  <th>Bus Licence Number</th>
+                  <th>Destination</th>
+                  
+            </tr>
+            <tr>
+                    <td>T1</td>
+                    
+                    <td>12-06-2019</td>
+                    <td>RAC101J</td>
+                    <td>KIVU LAKE</td>
+   
+     
+   
+               </tr>
+               <tr>
+                       <td>T4</td>
+                       
+                       <td>12-06-2019</td>
+                       <td>RAC101J</td>
+                       <td>Mary Holy Land</td>
+      
+        
+      
+                  </tr>
+                  <tr>
+                       <td>T6</td>
+                       
+                       <td>12-06-2019</td>
+                       <td>RAC101G</td> 
+                       <td>Nyungwe National Park</td>   
+        
+                     </tr>
+                     <tr>
+                            <td>T7</td>
+                            
+                            <td>12-06-2019</td>
+                            <td>RAC101J</td>
+                            <td>Akagera National Park</td>
+           
+             
+           
+                       </tr>
+                       <tr>
+                               <td>T9</td>
+                               
+                               <td>12-06-2019</td>
+                               <td>RAC190B</td>
+                               <td>Akagera National Park</td>
+              
+                
+              
+                          </tr>
+                          <tr>
+                                <td>T9</td>
+                                
+                                <td>12-06-2019</td>
+                                <td>RAC190B</td>
+                                <td>Richard kandt</td>
+               
+                 
+               
+                           </tr>
+                          <tr>
+                               <td>12</td>
+                               
+                               <td>12-06-2019</td>
+                               <td>RAD999N</td>
+                               <td>Nyanza Museum </td>
+              
+                
+              
+                          </tr>
+
+          </table>
+
+          
+        
+        </div>
+       
+        </div>
+    </body>
+    </html>


### PR DESCRIPTION
#### What does this PR do?
Allowing valid users should see filtered trips based on destination
#### Description of Task to be completed?
As a user can get destination filtered trips

Given a validated user
WHEN a user clicks on Destination Trip filter link from navigation Menu
THEN he/ she will be redirected to trips based on destination

Dev notes

200 OK
#### How should this be manually tested?
After cloning the repo you open UI/HTML Folder  you can browse by clicking on basedOnDestination.html or being redirected after clicking on Destination trip filter 

#### What are the relevant pivotal tracker stories?
[16761403 ](https://www.pivotaltracker.com/story/show/16761403 )