### PR TITLE
#167724835 Admin should see alltrips after login 

### DIFF
--- a/UI/html/bookingHistory.html
+++ b/UI/html/bookingHistory.html
@@ -1,0 +1,50 @@
+<html><header>
+    <title>wayfare add trip</title>
+<link href="../css/style.css" type="text/css" rel="stylesheet"></header>
+<body>
+<div class="navbar">
+<h3 class="text-primary"> wayfare transportation</h3>
+</div>
+
+    <div class="menu">
+        <ul>
+                <li><a href="allTrips.html" class="activeAdmin">All Trips</a></li>        
+                <li><a href="createTrip.html">Create Trip</a></li>
+                <li><a href="signUp.html">Account</a></li>
+                <li><a href="bookingHistory.html">Bookings</a></li>                
+                </ul>
+    </div>
+    <table class="table-stripped">
+        <tr><th colspan="6"><h4 class="text-primary">All user  Bookings in System</h4></th></tr>
+<tr>
+    <th>trip id</th><th>booking id</th><th>Booked By</th><th>phone number</th><th>Bus licence number</th>
+</tr>
+<tr>
+    <td>T1</td><td>32</td><td>Alice</td><td>+250785432901</td><td>RAC001D</td>
+</tr>
+<tr>
+    <td>T1</td><td>33</td><td>christophe</td><td>+250785455901</td><td>RAE001F</td>
+</tr>
+<tr>
+    <td>T1</td><td>34</td><td>John Smith</td><td>+250785432955</td><td>RAD141x</td>
+</tr>
+<tr>
+    <td>T1</td><td>32</td><td>Alice</td><td>+250785432901</td><td>RAC001D</td>
+</tr>
+<tr>
+    <td>T2</td><td>35</td><td>john Smith</td><td>+250781129708</td><td>RAE001F</td>
+</tr>
+<tr>
+    <td>T2</td><td>36</td><td>Alice</td><td>+250785432901</td><td>RAD141x</td>
+</tr>
+<tr>
+    <td>T2<td>37</td><td>Alicia</td><td>+250780032901</td><td>RAC001D</td>
+</tr>
+<tr>
+    <td>T3</td><td>38</td><td>Muhire</td><td>+250785432921</td><td>RAE001F</td>
+</tr>
+<tr>
+    <td>T3</td><td>39</td><td>jean paul</td><td>+250785432201</td><td>RAD141x</td>
+</tr>
+
+    </table>


### PR DESCRIPTION
### What does this PR do?
Allowing logged in admin to see all trips
### Description of Task to be completed?
 Currently:

When an admin signed in he is redirected to create a trip page
 Expected

Admin should be able to view all his trips when he/she logs in
 STEPS TO PRODUCE

. Enter username and password
. Click on the admin sign-in button

### How should this be manually tested?
After cloning the repo you open UI/HTML Folder  you can browse by clicking on index.html to login thus you will be redirected to alltrips.html page
### What are the relevant pivotal tracker stories?
[167724835](https://www.pivotaltracker.com/story/show/167724835)